### PR TITLE
Adding Hexameter to the list of libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 * [GenesisEngine](https://github.com/SaintGimp/GenesisEngine) - GenesisEngine allows you to create and explore procedurally-generated planetary systems, from ground level all the way out into space. Experiments with procedurally-generated worlds, XNA, and design patterns.
 * [Gladiator 3D](https://github.com/krotik/gladiator_3d) - Canvas based JavaScript ray casting engine for pseudo 3D games.
 * [Godot](https://github.com/okamstudio/godot) - Fully featured, MIT licensed, game engine. It focuses on having great tools, and a visual oriented workflow that can export to PC, Mobile and Web platforms with no hassle. The editor, language and APIs are feature rich, yet simple to learn, allowing you to become productive in a matter of hours.
+* [Hexameter](https://github.com/Hexworks/hexameter) - Hexagonal Grid library with MIT license. Provides a convenient API to create and manage Hexagonal grids while does not tie the user to any GUI library. Also provides commonly used operations for Hexagonal Grids like distance calculation and pixel-to-coordinate conversion.
 * [JiGS](https://github.com/Techbot/JiGS-PHP-RPG-engine) - Online RPG and Trading Game Engine built in PHP.
 * [jMonkeyEngine](https://github.com/jMonkeyEngine/jmonkeyengine) - Cutting edge, cross-platform 3D game engine for adventurous Java developers.
 * [kiwi.js](https://github.com/gamelab/kiwi.js) - Blazingly fast mobile & desktop browser based HTML5 game framework. It uses CocoonJS for publishing to the AppStore.


### PR DESCRIPTION
Hexagonal Grid library with MIT license. Provides a convenient API to create and manage Hexagonal grids while does not tie the user to any GUI library. Also provides commonly used operations for Hexagonal Grids like distance calculation and pixel-to-coordinate conversion.